### PR TITLE
when the file gets compiled/transformed the attribute (attributes is not being propagated)

### DIFF
--- a/GspResourcesGrailsPlugin.groovy
+++ b/GspResourcesGrailsPlugin.groovy
@@ -3,7 +3,7 @@ import org.grails.plugin.resource.gsp.GspResourcePageRenderer
 import org.grails.plugin.resource.gsp.GspResourceProcessor
 
 class GspResourcesGrailsPlugin {
-    def version = "0.31"
+    def version = "0.31.1"
     def grailsVersion = "2.0.0 > *"
     def dependsOn = [
         'resources': '1.1.5 > *',

--- a/grails-app/resourceMappers/org/grails/plugin/resource/gsp/GspResourceMapper.groovy
+++ b/grails-app/resourceMappers/org/grails/plugin/resource/gsp/GspResourceMapper.groovy
@@ -64,6 +64,7 @@ class GspResourceMapper {
                 gspResource.contentType = resource.contentType
                 gspResource.disposition = resource.disposition
                 gspResource.gsp = gsp
+                gspResource.attributes = resource.attributes
                 gspResource.gspResourceLocator = gspResourceLocator
                 gspResource.gspResourcePageRenderer = gspResourcePageRenderer
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
Hi Guys, 

Thanks for the plugin, I've been digging in the code and found it great,

There is a particular issue I faced using this plugin on the project I'm currently working on, if we define a gsp resource like:

resource url:[dir:'css', file:'technology.basic.less.gsp', plugin:'vw-plugin-cps-vw-section'],attrs:[rel: "stylesheet/less", type:'css', media:'all'], attributes:[dirDependencies:[[plugin:'vw-plugin-cps-core', directories:['/css/lib', '/css/helper']]]], bundle:'bundle_technology_style'

The attribute (attributes) is getting lost when the resource is transformed on the version 0.31,

This version propagates the attribute (attributes) so when the new resource is manipulated the mapper still have access to it,

Cheers,
Jorge
