### PR TITLE
preserving the type defined by the resource

### DIFF
--- a/GspResourcesGrailsPlugin.groovy
+++ b/GspResourcesGrailsPlugin.groovy
@@ -3,7 +3,7 @@ import org.grails.plugin.gspresources.GspResourcePageRenderer
 import org.grails.plugin.gspresources.GspResourceProcessor
 
 class GspResourcesGrailsPlugin {
-    def version = "0.4"
+    def version = "0.4.1"
     def grailsVersion = "2.0.0 > *"
     def dependsOn = [
         'resources': '1.1.5 > *',

--- a/src/groovy/org/grails/plugin/gspresources/GspResourceProcessor.groovy
+++ b/src/groovy/org/grails/plugin/gspresources/GspResourceProcessor.groovy
@@ -474,7 +474,7 @@ class GspResourceProcessor extends ResourceProcessor {
 
         // Set the type tag attribute
         if (resource.tagAttributes == null) resource.tagAttributes = [:]
-        resource.tagAttributes.type = getResourceTypeFromUri(resource.actualUrl)
+        resource.tagAttributes.type = resource.tagAttributes.type ?: getResourceTypeFromUri(resource.actualUrl)
         
         // Now create the synthetic resource that this resource is going to delegate to
         def rendered = findSyntheticResourceById(resource.actualUrl)


### PR DESCRIPTION
Thanks for the great job done here, I was looking forward to this version. 

As part of my configuration I have some resources as *.less.gsp .

The problem I'm facing is that the type is currently being taken from the file's extension in my case [less](this is then processed by the less plugin) which is not supported by resources plugin, so it'd be good to be able to set the type of the resource when it's defined otherwise this plugin will work the type out from the file's extension,

Cheers
