### PR TITLE
Fix for bad dependencies

### DIFF
--- a/GspResourcesGrailsPlugin.groovy
+++ b/GspResourcesGrailsPlugin.groovy
@@ -3,7 +3,7 @@ import org.grails.plugin.gspresources.GspResourcePageRenderer
 import org.grails.plugin.gspresources.GspResourceProcessor
 
 class GspResourcesGrailsPlugin {
-    def version = "0.4.1"
+    def version = "0.4.2-SNAPSHOT"
     def grailsVersion = "2.0.0 > *"
     def dependsOn = [
         'resources': '1.1.5 > *',

--- a/application.properties
+++ b/application.properties
@@ -1,8 +1,8 @@
 #Grails Metadata file
-#Wed Jun 20 00:17:07 HKT 2012
-app.grails.version=2.0.3
+#Thu Jun 20 11:46:32 BST 2013
+app.grails.version=2.2.2
 app.name=gsp-resources
 app.servlet.version=2.5
-plugins.hibernate=2.0.3
+plugins.hibernate=2.2.2
 plugins.rest-client-builder=1.0.2
-plugins.tomcat=2.0.3
+plugins.tomcat=2.2.2

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -29,9 +29,10 @@ grails.project.dependency.resolution = {
     dependencies {
     }
     plugins {
-        build(":release:latest.integration") {
+        build ':release:2.2.1', ':rest-client-builder:1.0.3', {
             export = false
         }
-        runtime "org.grails.plugins:resources:latest.integration"
+
+        runtime "org.grails.plugins:resources:1.2"
     }
 }


### PR DESCRIPTION
The dependencies force latest.integration and this breaks now with Grails 2 where release-plugin has a latest.integration of 3.0.0 which only runs with Grails 2.3 and not 2.2.x.
